### PR TITLE
fixed issue with library not allowing metadata to be optional. You can now successfully exclude metadata without issues. Increased sdk to 34, added check for email, removed secret key and other irrelevant data from being sent in payload.

### DIFF
--- a/Paystack-webview-android/build.gradle
+++ b/Paystack-webview-android/build.gradle
@@ -22,7 +22,7 @@ android {
 
                     groupId = 'com.github.VhiktorBrown'
                     artifactId = 'Paystack-webview-android'
-                    version = '1.0.6'
+                    version = 'v1.0.7'
                 }
             }
         }

--- a/Paystack-webview-android/src/main/java/com/theelitedevelopers/paystackwebview/PayStackWebViewForAndroid.java
+++ b/Paystack-webview-android/src/main/java/com/theelitedevelopers/paystackwebview/PayStackWebViewForAndroid.java
@@ -94,14 +94,26 @@ public class PayStackWebViewForAndroid extends PayStackManager {
      * @return - this.
      */
     public PayStackInitializer getDataWithJsonMetaData(PayStackInitializer payStackInitializer){
-        return new PayStackInitializer(
-                payStackInitializer.getSecretKey(),
-                payStackInitializer.getEmail(),
-                payStackInitializer.getAmount(),
-                payStackInitializer.getCallback_url(),
-                payStackInitializer.isShow(),
-                Utils.convertFromStringToJson(payStackInitializer.getTemporaryMetaData())
-        );
+        //Check to see if user added the metadata. If so, we use the constructor
+        //that includes the metadata, if not, we use a different constructor.
+        if(payStackInitializer.getMetaData() != null){
+            return new PayStackInitializer(
+                    payStackInitializer.getSecretKey(),
+                    payStackInitializer.getEmail(),
+                    payStackInitializer.getAmount(),
+                    payStackInitializer.getCallback_url(),
+                    payStackInitializer.isShow(),
+                    Utils.convertFromStringToJson(payStackInitializer.getTemporaryMetaData())
+            );
+        }else {
+            return new PayStackInitializer(
+                    payStackInitializer.getSecretKey(),
+                    payStackInitializer.getEmail(),
+                    payStackInitializer.getAmount(),
+                    payStackInitializer.getCallback_url(),
+                    payStackInitializer.isShow()
+            );
+        }
     }
 
 

--- a/Paystack-webview-android/src/main/java/com/theelitedevelopers/paystackwebview/data/models/PayStackInitializer.java
+++ b/Paystack-webview-android/src/main/java/com/theelitedevelopers/paystackwebview/data/models/PayStackInitializer.java
@@ -37,6 +37,14 @@ public class PayStackInitializer implements Parcelable {
         this.metaData = metaData;
     }
 
+    public PayStackInitializer(String secretKey, String email, double amount, String callback_url, boolean show) {
+        this.secretKey = secretKey;
+        this.email = email;
+        this.amount = amount;
+        this.callback_url = callback_url;
+        this.show = show;
+    }
+
     protected PayStackInitializer(Parcel in) {
         secretKey = in.readString();
         email = in.readString();

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 The Android library that helps developers integrate Paystack's payment gateway with just few lines of code. The library automatically loads Paystack's payment gateway in a WebView, saving you the stress of dealing with Webview's complex configuration, fetches an authorization URL from Paystack, handles payment and returns a SUCCESS RESULT back to your Activity or Fragment, if transaction was successful.
 
 ## Changes/Updates(1st September 2024)
+- MetaData Error Issue: Issue with library not allowing metadata to be optional has been fixed. You can now easily exclude metadata without experiencing issues.
 - Upgraded Library: The library has been upgraded to support Android SDK 34. This ensures compatibility with the latest Android devices and features.
 - Payload Optimization: Unnecessary details in the payload sent to Paystack have been removed. This improves efficiency and reduces data transmission size.
 - Email Validation: A check for email has been added to ensure an email address is provided before sending a request to Paystack. This helps prevent errors and ensures proper communication with the user.
@@ -48,7 +49,7 @@ The Android library that helps developers integrate Paystack's payment gateway w
   
   ``` java
   dependencies {
-	        implementation 'com.github.VhiktorBrown:Paystack-webview-android:v1.0.6'
+	        implementation 'com.github.VhiktorBrown:Paystack-webview-android:v1.0.7'
   }
   ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     //Ssp and Sdp
     implementation 'com.intuit.sdp:sdp-android:1.0.6'
     implementation 'com.intuit.ssp:ssp-android:1.0.6'
-//    implementation 'com.github.VhiktorBrown:Paystack-webview-android:1.0.5'
+    //implementation 'com.github.VhiktorBrown:Paystack-webview-android:v1.0.6'
 
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation project(':Paystack-webview-android')

--- a/app/src/main/java/com/theelitedevelopers/paystackwebviewforandroid/MainActivity.java
+++ b/app/src/main/java/com/theelitedevelopers/paystackwebviewforandroid/MainActivity.java
@@ -33,7 +33,6 @@ public class MainActivity extends AppCompatActivity {
                 .setSecretKey("secret_key")
                 .setCallbackURL("https://transaction_callback_url")
                 .showProgressBar(true)
-                .setMetaData(payStackData)
                 .initialize());
     }
 


### PR DESCRIPTION
fixed issue with library not allowing metadata to be optional. You can now successfully exclude metadata without issues. Increased sdk to 34, added check for email, removed secret key and other irrelevant data from being sent in payload.